### PR TITLE
Updated spec & readme with context extension, first formal spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ FDC3 Intents specifications, schemas, and examples
 * Standard context and intent definitions let us create workflows on the fly
 
 FDC3 Intents define a standard set of verbs that can be used to put together common cross-application workflows on the financial desktop.
-* Applications register intents they support
-* The registries support app discovery by intent
+* Applications register actions they support, and action is a verb applied to a context
+* The registries support app discovery by intents or context
 * Intents are not full RPC, Apps don’t need to enumerate every function with an intent
 * FDC3 Standard intents are a limited set, organizations can create their own intents
 
@@ -44,4 +44,9 @@ fdc3.open(null,"StartChat",{
       email:"nick@openfin.co"
      }
 } ]});
+```
+
+**Discovering apps that have intents for context type "contact"**
+```javascript
+let availableContactHandlers = fdc3.resolve(null,"contact");
 ```

--- a/Specification-Draft.MD
+++ b/Specification-Draft.MD
@@ -2,8 +2,8 @@
 ## FDC3 Intents Overview ##
 FDC3 Intents define a standard set of nouns and verbs that can be used to put together common cross-application workflows on the financial desktop.  
 
-* Applications register intents they support
-* The registries support app discovery by intent
+* Applications register actions they support, and action is a verb applied to a context
+* The registries support app discovery by intent or context
 * Intents are not full RPC, Apps don’t need to enumerate every function with an intent
 * FDC3 Standard intents are a limited set, organizations can create their own intents
 
@@ -32,37 +32,27 @@ However, there is a need for applications to ensure that their intents avoid col
 
 ## Initial Set of Intents ##
 
-* DialCall
-    * Context: contact
-    * Expected behavior: dial the contact number (TBD), but don’t initiate the call
-* SaveContact
-    * Context: Contact
-    * Expected behavior: contact will be saved by the application - for example, CRM or Chat contacts
-* SaveInstrument
-    * Context: Instrument
-    * Expected behavior: save instrument to a monitor or similar application
-* ShareContext
-    * Context: App Context
-    * Expected behavior: initiate social share of the context 
 * StartCall
-    * Context: contact
-    * Expected behavior: initiate call with contact(s)
+  * Expected Context: Contact
+  * Expected behavior: initiate call with contact(s)
 * StartChat
-  * Context: contact
+  * Expected Context: Contact
   * Expected behavior: initiate chat with contact(s)
 * ViewChart
-   * Context: Instrument
-   * Expected behavior: display a chart for the context
+  * Expected Context: Instrument
+  * Expected behavior: display a chart for the context
 * ViewContact
-   * Context: Contact
-   * Expected behavior: display details of a contact
+  * Expected Context: Contact
+  * Expected behavior: display details of a contact
 * ViewQuote
-   * Context: Instrument
-   * Expected behavior: display pricing for an instrument
+  * Expected Context: Instrument
+  * Expected behavior: display pricing for an instrument
 * ViewNews
-   * Context: Any
-   * Expected behavior: display news for a given context
-
-
-**Note:**
-The sharing intent introduces the idea of sharing an App context.  This is a new context type that recreates the state of an App.  Needs to be defined in the Context Data spec.
+  * Expected Context: Instrument, Contact, Organisation, etc.
+  * Expected behavior: display news for a given context
+* ViewInstument
+  * Expected Context: Instrument
+  * Expected behavior: display relevant information for a given instrument
+* ViewAnalysis
+  * Expected Context: Instrument, Organization, etc.
+  * Expected behavior: Send context to receiving application for displaying analysis

--- a/src/directory.d.ts
+++ b/src/directory.d.ts
@@ -1,0 +1,19 @@
+import { IntentType } from './intents';
+/**
+ * An application in the app directory
+ */
+export interface IApplication {
+    id: number;
+    name: string;
+    title: string;
+    manifest_url: string;
+    description: string;
+    contact_email: string;
+    support_email: string;
+    signature: string;
+    publisher: string;
+    icon: string;
+    appPage: string;
+    images: { url: string; }[];
+    actions: { intent: IntentType; context: string; }[];
+}

--- a/src/intents.d.ts
+++ b/src/intents.d.ts
@@ -1,0 +1,56 @@
+/** Enumeration of the standard FDC3 Intents */
+export declare enum Intents {
+    /**
+     * Expected Context: Contact
+     *
+     * Expected behavior: initiate call with contact(s)
+     */
+    START_CALL = "StartCall",
+    /**
+     * Expected Context: Contact
+     *
+     * Expected behavior: initiate chat with contact(s)
+     */
+    START_CHAT = "StartChat",
+    /**
+     * Expected Context: Contact
+     *
+     * Expected behavior: display details of a contact
+     */
+    VIEW_CONTACT = "ViewContact",
+    /**
+     * Expected Context: Instrument
+     *
+     * Expected behavior: display a chart for the context
+     */
+    VIEW_CHART = "ViewChart",
+    /**
+     * Expected Context: Instrument
+     *
+     * Expected behavior: display pricing for an instrument
+     */
+    VIEW_QUOTE = "ViewQuote",
+    /**
+     * Expected Context: Instrument, Contact, Organisation, etc.
+     *
+     * Expected behavior: display news for a given context
+     */
+    VIEW_NEWS = "ViewNews",
+    /**
+     * Expected Context: Instrument
+     * 
+     * Expected behavior: display relevant information for a given instrument
+     */
+    VIEW_INSTRUMENT = "ViewInstument",
+    /**
+     * Expected Context: Instrument, Organization, etc.
+     * 
+     * Expected behavior: Send context to receiving application for displaying analysis
+     */
+    VIEW_ANALYSIS = "ViewAnalysis",
+}
+/**
+ * Type that can be used to validate the name of an intent. Accepts a value from the 'Intents' enum, or any any of the
+ * string constants from that enum. Custom intents can be passed in as a general string.
+ */
+export declare type IntentType = (keyof typeof Intents) | Intents | string;

--- a/src/intents_displayname.json
+++ b/src/intents_displayname.json
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "StartCall",
+        "displayName": "Call"
+    },
+    {
+        "name": "StartChat",
+        "displayName": "Chat"
+    },
+    {
+        "name": "ViewChart",
+        "displayName": "Chart"
+    },
+    {
+        "name": "ViewContact",
+        "displayName": "View"
+    },
+    {
+        "name": "ViewQuote",
+        "displayName": "Quote"
+    },
+    {
+        "name": "ViewNews",
+        "displayName": "News"
+    },
+    {
+        "name": "ViewInstrument",
+        "displayName": "Details"
+    },
+    {
+        "name": "ViewAnalysis",
+        "displayName": "Analyze"
+    }
+]


### PR DESCRIPTION
Updated specification and readme to be in line with proposal on last Intents WG meeting.
Added formal specification in Typescript for
- Initial list of intents
- Updated definition for application scheme, including actions = intent + context
- Display name file that can be used as seed/example for right click menus etc