### PR TITLE
Adding data type information for data-driven intents.

### DIFF
--- a/Specification-Draft.MD
+++ b/Specification-Draft.MD
@@ -20,7 +20,7 @@ FDC3 Intents define a standard set of nouns and verbs that can be used to put to
 * Atomic
     * There should be clear lines in a workflow where the object begins and ends
 * Stateless
-    * Workflows should not require callbacks or endpoints to maintain references to each other.  Once an intent is passed to an endpoint - it controls the rest of that workflow. 
+    * Workflows should not require callbacks or endpoints to maintain references to each other.  With the exception of specifically data-driven intents, once an intent is passed to an endpoint - it controls the rest of that workflow.
 * Specific
     * Terms should not be so open-ended that one endpoint could fulfill the intent in a completely different way than another
 * Distinct

--- a/src/Intent.yaml
+++ b/src/Intent.yaml
@@ -23,6 +23,16 @@ Intent:
       description: The contexts the intent accepts. This will
         typically be a set of namespaced context types, e.g. 
         "org.symphony.contact"
+    dataReturnType: 
+      type: string
+      description: If there is a data payload associated with the intent resolution, specifies the type.  
+      This value can be either a URL to the type definition, or an alias for the type.  
+      If this value is set, the desktop agent can manage the resolution of the intent accordingly.
+    dataInputType: 
+      type: string
+      description: If there is a data payload associated with the intent, specifies the type expected.  
+      This value can be either a URL to the type definition, or an alias for the type.  
+      If this value is set, the desktop agent can manage the validation and resolution of the intent accordingly.
     customConfig:
         type: object
         description: Custom configuration for the intent


### PR DESCRIPTION
This PR is to address the handling of data-driven intents that can be raised in current API draft spec.  By providing a place to specify type for both payload of input and output of an  intent, we give the scaffolding for desktop agents to perform the following functions:

- Manage the timing of resolving the Promise for a raised intent.  If an intent has no data payload, it should be resolved as soon as it is routed.  If an intent has a data return defined, the desktop agent should wait to resolve until the handling app has returned the (valid) data.
- Validate data payloads, both when an intent is raised and is being routed (if there is a type specified for the input), and when resolving.